### PR TITLE
Støtt opprettelse av dialog med sykmelding som vedlegg

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,37 @@
+name: Publish Snapshot
+
+on:
+  push:
+    branches:
+      - dev/**
+
+jobs:
+  publish-snapshot:
+    env:
+      ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Ensure Gradle Wrapper is Downloaded
+        run: ./gradlew --version
+
+      - name: Get Version
+        run:  echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV
+
+      - name: Print Project Version
+        run: echo "Project version is ${{ env.CURRENT_VERSION }}"
+
+      - name: Publish artifact
+        if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
+        run: ./gradlew publish

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,6 +21,9 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
+      - name: Ensure Gradle Wrapper is Downloaded
+        run: ./gradlew --version
+
       - name: Get Version
         run:  echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,17 +14,12 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Ensure Gradle Wrapper is Downloaded
-        run: ./gradlew --version
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Get Version
         run:  echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.2"
+version = "0.0.2-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.2-SNAPSHOT"
+version = "0.0.3-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.4"
+version = "0.0.3"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.3-SNAPSHOT"
+version = "0.0.4"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.3"
+version = "0.0.3-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.3-SNAPSHOT"
+version = "0.0.4-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.3-sykmelding-SNAPSHOT"
+version = "0.0.3"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.4-SNAPSHOT"
+version = "0.0.3-sykmelding-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
@@ -11,25 +11,8 @@ data class CreateDialogRequest(
     val status: String,
     val content: Content,
     val guiActions: List<GuiAction>,
+    val transmissions: List<Transmission>,
 ) {
-    @Serializable
-    data class Content(
-        val title: ContentValue,
-        val summary: ContentValue,
-    )
-
-    @Serializable
-    data class ContentValue(
-        val value: List<ContentValueItem>,
-        val mediaType: String = "text/plain",
-    )
-
-    @Serializable
-    data class ContentValueItem(
-        val value: String,
-        val languageCode: String = "nb",
-    )
-
     @Serializable
     data class GuiAction(
         val action: String,
@@ -40,11 +23,78 @@ data class CreateDialogRequest(
     )
 }
 
+@Serializable
+data class Content(
+    val title: ContentValue,
+    val summary: ContentValue,
+)
+
+@Serializable
+data class ContentValue(
+    val value: List<ContentValueItem>,
+    val mediaType: String = "text/plain",
+)
+
+@Serializable
+data class ContentValueItem(
+    val value: String,
+    val languageCode: String = "nb",
+)
+
+@Serializable
+data class Transmission(
+    val type: TransmissionType,
+    val sender: Sender,
+    val content: Content,
+    val attachments: List<Attachment>,
+
+    ) {
+    @Serializable
+    data class Sender(
+        val actorType: String,
+    )
+
+    @Serializable
+    enum class TransmissionType {
+        // For general information, not related to any submissions
+        Information,
+
+        // Feedback/receipt accepting a previous submission
+        Acceptance,
+
+        // Feedback/error message rejecting a previous submission
+        Rejection,
+
+        // Question/request for more information
+        Request,
+    }
+
+    @Serializable
+    data class Attachment(
+        val displayName: ContentValueItem,
+        val urls: List<Url>,
+    )
+
+    @Serializable
+    data class Url(
+        val url: String,
+        val mediaType: String,
+        val consumerType: AttachmentUrlConsumerType,
+    )
+
+    @Serializable
+    enum class AttachmentUrlConsumerType {
+        Gui,
+        Api,
+    }
+
+}
+
 fun lagContentValue(verdi: String) =
-    CreateDialogRequest.ContentValue(
+    ContentValue(
         value =
             listOf(
-                CreateDialogRequest.ContentValueItem(
+                ContentValueItem(
                     value = verdi,
                 ),
             ),
@@ -58,7 +108,7 @@ fun lagGuiAction(
     url = url,
     title =
         listOf(
-            CreateDialogRequest.ContentValueItem(
+            ContentValueItem(
                 value = tittel,
             ),
         ),
@@ -78,6 +128,46 @@ fun lagCreateDialogRequest(
         party = "urn:altinn:organization:identifier-no:$orgnr",
         status = status,
         externalRefererence = UUID.randomUUID().toString(),
-        content = CreateDialogRequest.Content(lagContentValue(tittel), lagContentValue(sammendrag)),
+        content = Content(lagContentValue(tittel), lagContentValue(sammendrag)),
         guiActions = listOf(lagGuiAction(url, knappTittel)),
+        transmissions = emptyList(),
+    )
+
+fun lagNyDialogRequestMedSykmelding(
+    ressurs: String,
+    orgnr: String,
+    dialogTittel: String,
+    dialogSammendrag: String,
+    sykmeldingId: String,
+    sykmeldingJsonUrl: String,
+): CreateDialogRequest =
+    CreateDialogRequest(
+        serviceResource = "urn:altinn:resource:$ressurs",
+        party = "urn:altinn:organization:identifier-no:$orgnr",
+        status = "New",
+        externalRefererence = sykmeldingId,
+        content = Content(lagContentValue(dialogTittel), lagContentValue(dialogSammendrag)),
+        guiActions = emptyList(),
+        transmissions = listOf(
+            Transmission(
+                type = Transmission.TransmissionType.Information,
+                sender = Transmission.Sender("ServiceOwner"),
+                content = Content(
+                    title = lagContentValue("Sykmelding"),
+                    summary = lagContentValue("Sykmelding")
+                ),
+                attachments = listOf(
+                    Transmission.Attachment(
+                        displayName = ContentValueItem("Sykmelding.json"),
+                        urls = listOf(
+                            Transmission.Url(
+                                url = sykmeldingJsonUrl,
+                                mediaType = "application/json",
+                                consumerType = Transmission.AttachmentUrlConsumerType.Api
+                            )
+                        )
+                    )
+                )
+            )
+        )
     )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
@@ -133,7 +133,7 @@ fun lagCreateDialogRequest(
         transmissions = emptyList(),
     )
 
-fun lagNyDialogRequestMedSykmelding(
+fun lagNyDialogMedSykmeldingRequest(
     ressurs: String,
     orgnr: String,
     dialogTittel: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
@@ -47,8 +47,7 @@ data class Transmission(
     val sender: Sender,
     val content: Content,
     val attachments: List<Attachment>,
-
-    ) {
+) {
     @Serializable
     data class Sender(
         val actorType: String,
@@ -87,7 +86,6 @@ data class Transmission(
         Gui,
         Api,
     }
-
 }
 
 fun lagContentValue(verdi: String) =
@@ -148,26 +146,30 @@ fun lagNyDialogMedSykmeldingRequest(
         externalRefererence = sykmeldingId.toString(),
         content = Content(lagContentValue(dialogTittel), lagContentValue(dialogSammendrag)),
         guiActions = emptyList(),
-        transmissions = listOf(
-            Transmission(
-                type = Transmission.TransmissionType.Information,
-                sender = Transmission.Sender("ServiceOwner"),
-                content = Content(
-                    title = lagContentValue("Sykmelding"),
-                    summary = lagContentValue("Sykmelding")
+        transmissions =
+            listOf(
+                Transmission(
+                    type = Transmission.TransmissionType.Information,
+                    sender = Transmission.Sender("ServiceOwner"),
+                    content =
+                        Content(
+                            title = lagContentValue("Sykmelding"),
+                            summary = lagContentValue("Sykmelding"),
+                        ),
+                    attachments =
+                        listOf(
+                            Transmission.Attachment(
+                                displayName = listOf(ContentValueItem("Sykmelding.json")),
+                                urls =
+                                    listOf(
+                                        Transmission.Url(
+                                            url = sykmeldingJsonUrl,
+                                            mediaType = "application/json",
+                                            consumerType = Transmission.AttachmentUrlConsumerType.Api,
+                                        ),
+                                    ),
+                            ),
+                        ),
                 ),
-                attachments = listOf(
-                    Transmission.Attachment(
-                        displayName = listOf(ContentValueItem("Sykmelding.json")),
-                        urls = listOf(
-                            Transmission.Url(
-                                url = sykmeldingJsonUrl,
-                                mediaType = "application/json",
-                                consumerType = Transmission.AttachmentUrlConsumerType.Api
-                            )
-                        )
-                    )
-                )
-            )
-        )
+            ),
     )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
@@ -138,14 +138,14 @@ fun lagNyDialogRequestMedSykmelding(
     orgnr: String,
     dialogTittel: String,
     dialogSammendrag: String,
-    sykmeldingId: String,
+    sykmeldingId: UUID,
     sykmeldingJsonUrl: String,
 ): CreateDialogRequest =
     CreateDialogRequest(
         serviceResource = "urn:altinn:resource:$ressurs",
         party = "urn:altinn:organization:identifier-no:$orgnr",
         status = "New",
-        externalRefererence = sykmeldingId,
+        externalRefererence = sykmeldingId.toString(),
         content = Content(lagContentValue(dialogTittel), lagContentValue(dialogSammendrag)),
         guiActions = emptyList(),
         transmissions = listOf(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
@@ -71,7 +71,7 @@ data class Transmission(
 
     @Serializable
     data class Attachment(
-        val displayName: ContentValueItem,
+        val displayName: List<ContentValueItem>,
         val urls: List<Url>,
     )
 
@@ -158,7 +158,7 @@ fun lagNyDialogRequestMedSykmelding(
                 ),
                 attachments = listOf(
                     Transmission.Attachment(
-                        displayName = ContentValueItem("Sykmelding.json"),
+                        displayName = listOf(ContentValueItem("Sykmelding.json")),
                         urls = listOf(
                             Transmission.Url(
                                 url = sykmeldingJsonUrl,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequest.kt
@@ -12,15 +12,19 @@ data class CreateDialogRequest(
     val content: Content,
     val guiActions: List<GuiAction>,
     val transmissions: List<Transmission>,
+)
+
+@Serializable
+data class GuiAction(
+    val action: String,
+    val url: String,
+    val title: List<ContentValueItem>,
 ) {
-    @Serializable
-    data class GuiAction(
-        val action: String,
-        val url: String,
-        val isDeleteDialogAction: Boolean = false,
-        val priority: String = "Primary",
-        val title: List<ContentValueItem>,
-    )
+    @Suppress("unused")
+    val priority = "Primary"
+
+    @Suppress("unused")
+    val isDeleteDialogAction = false
 }
 
 @Serializable
@@ -32,14 +36,18 @@ data class Content(
 @Serializable
 data class ContentValue(
     val value: List<ContentValueItem>,
-    val mediaType: String = "text/plain",
-)
+) {
+    @Suppress("unused")
+    val mediaType: String = "text/plain"
+}
 
 @Serializable
 data class ContentValueItem(
     val value: String,
-    val languageCode: String = "nb",
-)
+) {
+    @Suppress("unused")
+    val languageCode: String = "nb"
+}
 
 @Serializable
 data class Transmission(
@@ -101,7 +109,7 @@ fun lagContentValue(verdi: String) =
 fun lagGuiAction(
     url: String,
     tittel: String,
-) = CreateDialogRequest.GuiAction(
+) = GuiAction(
     action = "read",
     url = url,
     title =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -84,5 +84,6 @@ class DialogportenClient(
     }
 }
 
-class DialogportenClientException(message: String) :
-    Exception(message)
+class DialogportenClientException(
+    message: String,
+) : Exception(message)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -59,7 +59,7 @@ class DialogportenClient(
         sykmeldingJsonUrl: String,
     ): Result<String> {
         val dialogRequest =
-            lagNyDialogRequestMedSykmelding(
+            lagNyDialogMedSykmeldingRequest(
                 ressurs = ressurs,
                 orgnr = orgnr,
                 dialogTittel = dialogTittel,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -76,8 +76,8 @@ class DialogportenClient(
                         setBody(dialogRequest)
                     }.body()
             }.recover { e ->
-                "Feil ved kall til Dialogporten".also {
-                    logger.error(it, e)
+                "Feil med kall til Dialogporten".also {
+                    logger.error(it)
                     sikkerLogger.error(it, e)
                 }
                 throw DialogportenClientException()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -49,6 +49,40 @@ class DialogportenClient(
             }
         return dialogResponse
     }
+
+    suspend fun opprettNyDialogMedSykmelding(
+        orgnr: String,
+        dialogTittel: String,
+        dialogSammendrag: String,
+        sykmeldingId: String,
+        sykmeldingJsonUrl: String,
+    ): Result<String> {
+        val dialogRequest =
+            lagNyDialogRequestMedSykmelding(
+                ressurs = ressurs,
+                orgnr = orgnr,
+                dialogTittel = dialogTittel,
+                dialogSammendrag = dialogSammendrag,
+                sykmeldingId = sykmeldingId,
+                sykmeldingJsonUrl = sykmeldingJsonUrl,
+            )
+        val dialogResponse: Result<String> =
+            runCatching<DialogportenClient, String> {
+                httpClient
+                    .post("$baseUrl/dialogporten/api/v1/serviceowner/dialogs") {
+                        header("Content-Type", "application/json")
+                        header("Accept", "application/json")
+                        setBody(dialogRequest)
+                    }.body()
+            }.recover { e ->
+                "Feil ved kall til Dialogporten".also {
+                    logger.error(it, e)
+                    sikkerLogger.error(it, e)
+                }
+                throw DialogportenClientException()
+            }
+        return dialogResponse
+    }
 }
 
 class DialogportenClientException :

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -57,7 +57,7 @@ class DialogportenClient(
         dialogSammendrag: String,
         sykmeldingId: UUID,
         sykmeldingJsonUrl: String,
-    ): Result<String> {
+    ): String {
         val dialogRequest =
             lagNyDialogMedSykmeldingRequest(
                 ressurs = ressurs,
@@ -67,22 +67,20 @@ class DialogportenClient(
                 sykmeldingId = sykmeldingId,
                 sykmeldingJsonUrl = sykmeldingJsonUrl,
             )
-        val dialogResponse: Result<String> =
-            runCatching<DialogportenClient, String> {
-                httpClient
-                    .post("$baseUrl/dialogporten/api/v1/serviceowner/dialogs") {
-                        header("Content-Type", "application/json")
-                        header("Accept", "application/json")
-                        setBody(dialogRequest)
-                    }.body()
-            }.recover { e ->
-                "Feil med kall til Dialogporten".also {
-                    logger.error(it)
-                    sikkerLogger.error(it, e)
-                }
-                throw DialogportenClientException()
+        return runCatching<DialogportenClient, String> {
+            httpClient
+                .post("$baseUrl/dialogporten/api/v1/serviceowner/dialogs") {
+                    header("Content-Type", "application/json")
+                    header("Accept", "application/json")
+                    setBody(dialogRequest)
+                }.body()
+        }.getOrElse { e ->
+            "Feil med kall til Dialogporten".also {
+                logger.error(it)
+                sikkerLogger.error(it, e)
             }
-        return dialogResponse
+            throw DialogportenClientException()
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -67,20 +67,12 @@ class DialogportenClient(
                 sykmeldingId = sykmeldingId,
                 sykmeldingJsonUrl = sykmeldingJsonUrl,
             )
-        return runCatching<DialogportenClient, String> {
-            httpClient
-                .post("$baseUrl/dialogporten/api/v1/serviceowner/dialogs") {
-                    header("Content-Type", "application/json")
-                    header("Accept", "application/json")
-                    setBody(dialogRequest)
-                }.body()
-        }.getOrElse { e ->
-            "Feil med kall til Dialogporten".also {
-                logger.error(it)
-                sikkerLogger.error(it, e)
-            }
-            throw DialogportenClientException()
-        }
+        return httpClient
+            .post("$baseUrl/dialogporten/api/v1/serviceowner/dialogs") {
+                header("Content-Type", "application/json")
+                header("Accept", "application/json")
+                setBody(dialogRequest)
+            }.body()
     }
 }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import java.util.UUID
 
 class DialogportenClient(
     private val baseUrl: String,
@@ -54,7 +55,7 @@ class DialogportenClient(
         orgnr: String,
         dialogTittel: String,
         dialogSammendrag: String,
-        sykmeldingId: String,
+        sykmeldingId: UUID,
         sykmeldingJsonUrl: String,
     ): Result<String> {
         val dialogRequest =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequestTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/CreateDialogRequestTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.dialogporten
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
@@ -45,7 +44,7 @@ class CreateDialogRequestTest :
                     "Gå til inntektsmeldingskjema på nav.no",
                 )
             guiAction.title.first().languageCode shouldBe "nb"
-            val requestString = jsonConfigEncodeDefaults.encodeToString(CreateDialogRequest.GuiAction.serializer(), guiAction)
+            val requestString = jsonConfigEncodeDefaults.encodeToString(GuiAction.serializer(), guiAction)
             val forventetString = "create-dialog-request/correctGuiAction.json".readResource().normalizeJsonString()
             requestString shouldBe forventetString
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
@@ -22,12 +22,13 @@ class DialogportenClientTest :
 
         test("Opprett dialog med sykmelding gir id tilbake") {
             val dialogportenClient = mockDialogportenClient(HttpStatusCode.Created, MockData.gyldingRespons)
-            dialogportenClient.opprettNyDialogMedSykmelding(
-                orgnr = MockData.orgnr,
-                dialogTittel = "testTittel",
-                dialogSammendrag = "testSammendrag",
-                sykmeldingId = UUID.randomUUID(),
-                sykmeldingJsonUrl = "testurl.no"
-            ).getOrNull() shouldBe MockData.gyldingRespons
+            dialogportenClient
+                .opprettNyDialogMedSykmelding(
+                    orgnr = MockData.orgnr,
+                    dialogTittel = "testTittel",
+                    dialogSammendrag = "testSammendrag",
+                    sykmeldingId = UUID.randomUUID(),
+                    sykmeldingJsonUrl = "testurl.no",
+                ).getOrNull() shouldBe MockData.gyldingRespons
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
@@ -26,7 +26,7 @@ class DialogportenClientTest :
                 orgnr = MockData.orgnr,
                 dialogTittel = "testTittel",
                 dialogSammendrag = "testSammendrag",
-                sykmeldingId = UUID.randomUUID().toString(),
+                sykmeldingId = UUID.randomUUID(),
                 sykmeldingJsonUrl = "testurl.no"
             ).getOrNull() shouldBe MockData.gyldingRespons
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
 import no.nav.helsearbeidsgiver.utils.test.resource.readResource
+import java.util.UUID
 
 class DialogportenClientTest :
     FunSpec({
@@ -17,5 +18,16 @@ class DialogportenClientTest :
             val dialogportenClient =
                 mockDialogportenClient(HttpStatusCode.BadRequest, "create-dialog-response/validation-error.json".readResource())
             shouldThrowExactly<DialogportenClientException> { dialogportenClient.opprettDialog(MockData.orgnr, "testurl").getOrThrow() }
+        }
+
+        test("Opprett dialog med sykmelding gir id tilbake") {
+            val dialogportenClient = mockDialogportenClient(HttpStatusCode.Created, MockData.gyldingRespons)
+            dialogportenClient.opprettNyDialogMedSykmelding(
+                orgnr = MockData.orgnr,
+                dialogTittel = "testTittel",
+                dialogSammendrag = "testSammendrag",
+                sykmeldingId = UUID.randomUUID().toString(),
+                sykmeldingJsonUrl = "testurl.no"
+            ).getOrNull() shouldBe MockData.gyldingRespons
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
@@ -29,6 +29,6 @@ class DialogportenClientTest :
                     dialogSammendrag = "testSammendrag",
                     sykmeldingId = UUID.randomUUID(),
                     sykmeldingJsonUrl = "testurl.no",
-                ).getOrNull() shouldBe MockData.gyldingRespons
+                ) shouldBe MockData.gyldingRespons
         }
     })

--- a/src/test/resources/create-dialog-request/correctGuiAction.json
+++ b/src/test/resources/create-dialog-request/correctGuiAction.json
@@ -1,12 +1,12 @@
 {
   "action": "read",
   "url": "https://arbeidsgiver.intern.dev.nav.no/im-dialog/8e1ac9cc-34d4-4342-b865-3fb5fe9b154c",
-  "isDeleteDialogAction": false,
-  "priority": "Primary",
   "title": [
     {
       "value": "Gå til inntektsmeldingskjema på nav.no",
       "languageCode": "nb"
     }
-  ]
+  ],
+  "priority": "Primary",
+  "isDeleteDialogAction": false
 }


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker å sende sykmeldinger til arbeidsgivere via Dialogporten.

**Løsning**
Legger til støtte for å opprette en ny dialog i Dialogporten som inneholder sykmeldingen som vedlegg (egentlig en url som peker på vårt sykmelding-API).