### PR TITLE
Legg til vedleggtyper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "1.0.1"
+version = "1.0.2"
 
 kotlin {
     compilerOptions {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenRequestUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenRequestUtils.kt
@@ -27,6 +27,7 @@ fun opprettDialogMedSykmeldingRequest(
                 lagVedleggTransmission(
                     transmissionTittel = "Sykmelding",
                     transmissionSammendrag = "Sykmelding",
+                    vedleggType = Transmission.ExtendedType.SYKMELDING,
                     vedleggNavn = "Sykmelding.json",
                     vedleggUrl = sykmeldingJsonUrl,
                     vedleggMediaType = "application/json",
@@ -43,6 +44,7 @@ fun oppdaterDialogMedSykepengesoknadRequest(soknadJsonUrl: String): List<AddTran
                     lagVedleggTransmission(
                         transmissionTittel = "Søknad om sykepenger",
                         transmissionSammendrag = "Søknad om sykepenger",
+                        vedleggType = Transmission.ExtendedType.SYKEPENGESOKNAD,
                         vedleggNavn = "soknad-om-sykepenger.json",
                         vedleggUrl = soknadJsonUrl,
                         vedleggMediaType = "application/json",
@@ -65,6 +67,7 @@ private fun lagContentValue(verdi: String) =
 private fun lagVedleggTransmission(
     transmissionTittel: String,
     transmissionSammendrag: String,
+    vedleggType: Transmission.ExtendedType,
     vedleggNavn: String,
     vedleggUrl: String,
     vedleggMediaType: String,
@@ -72,6 +75,7 @@ private fun lagVedleggTransmission(
 ): Transmission =
     Transmission(
         type = Transmission.TransmissionType.Information,
+        extendedType = vedleggType,
         sender = Transmission.Sender("ServiceOwner"),
         content =
             Content(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Transmission(
     val type: TransmissionType,
+    val extendedType: ExtendedType,
     val sender: Sender,
     val content: Content,
     val attachments: List<Attachment>,
@@ -27,6 +28,15 @@ data class Transmission(
 
         // Question/request for more information
         Request,
+    }
+
+    /**
+     *  Kan brukes av LPS-systemer til å gjenkjenne ulike typer vedlegg (f.eks. sykmelding eller søknad om sykepenger).
+     */
+    @Serializable
+    enum class ExtendedType {
+        SYKMELDING,
+        SYKEPENGESOKNAD,
     }
 
     @Serializable


### PR DESCRIPTION
**Bakgrunn**
LPSene trenger å måte å gjenkjenne ulike vedlegg vi legger inn i Dialogporten.

**Løsning**
Vedlegget har ikke en type eller referanse som vi kan sette, men transmissionen har et felt `ExtendedType` hvor vi kan legge inn vår egen type (jeg ser for meg at vi kommer til å ha `SYKMELDING`, `SYKEPENGESOKNAD` og muligens `SYKEPENGEVEDTAK` som de tre vedleggstypene vi kommer til å sende til arbeidsgiver). 

Tar gjerne innspill på forslaget mitt.

I Altinn sin [transmission-dokumentasjon](https://docs.altinn.studio/dialogporten/reference/entities/transmission/) står dette om `ExtendedType`: 
```
ExtendedType (optional) string (uri)

Arbitrary URI/URN describing a service-specific transmission type. 
Refer to the service-specific documentation provided by the service owner for details (if in use).
```