### PR TITLE
Legg til mulighet til å sette external reference på transmissions

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
@@ -11,6 +11,7 @@ import java.util.UUID
 data class Transmission(
     val type: TransmissionType,
     val extendedType: String,
+    val externalReference: String?,
     val sender: Sender,
     val content: Content,
     val relatedTransmissionId: UUID? = null,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -7,6 +7,7 @@ abstract class TransmissionRequest {
     val vedleggMediaType = ContentType.Application.Json.toString()
     val vedleggConsumerType = Transmission.AttachmentUrlConsumerType.Api
     abstract val extendedType: String
+    abstract val externalReference: String?
     abstract val tittel: String
     abstract val sammendrag: String?
     abstract val vedleggNavn: String
@@ -19,6 +20,7 @@ fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmi
     Transmission(
         type = transmissionRequest.type,
         extendedType = transmissionRequest.extendedType,
+        externalReference = transmissionRequest.externalReference,
         sender = Transmission.Sender("ServiceOwner"),
         relatedTransmissionId = transmissionRequest.relatedTransmissionId,
         content =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -7,11 +7,11 @@ abstract class TransmissionRequest {
     val vedleggMediaType = ContentType.Application.Json.toString()
     val vedleggConsumerType = Transmission.AttachmentUrlConsumerType.Api
     abstract val extendedType: String
-    abstract val externalReference: String?
+    abstract val dokumentId: UUID
     abstract val tittel: String
     abstract val sammendrag: String?
     abstract val vedleggNavn: String
-    abstract val vedleggUrl: String
+    abstract val vedleggBaseUrl: String
     abstract val type: Transmission.TransmissionType
     abstract val relatedTransmissionId: UUID?
 }
@@ -20,7 +20,7 @@ fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmi
     Transmission(
         type = transmissionRequest.type,
         extendedType = transmissionRequest.extendedType,
-        externalReference = transmissionRequest.externalReference,
+        externalReference = transmissionRequest.dokumentId.toString(),
         sender = Transmission.Sender("ServiceOwner"),
         relatedTransmissionId = transmissionRequest.relatedTransmissionId,
         content =
@@ -35,7 +35,7 @@ fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmi
                     urls =
                         listOf(
                             Transmission.Url(
-                                url = transmissionRequest.vedleggUrl,
+                                url = "${transmissionRequest.vedleggBaseUrl}/${transmissionRequest.dokumentId}",
                                 mediaType = transmissionRequest.vedleggMediaType,
                                 consumerType = transmissionRequest.vedleggConsumerType,
                             ),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
@@ -27,6 +27,7 @@ class DialogportenClientTest :
                 Transmission(
                     type = Transmission.TransmissionType.Information,
                     extendedType = "extendedType",
+                    externalReference = "externalReference",
                     sender = Transmission.Sender(actorType = "actorType"),
                     content = Content.create("title", null),
                     attachments = emptyList(),


### PR DESCRIPTION
Dette var noe som ble etterlyst av leverandørene, så de skal slippe å parse dokument-idene (sykmelding-ID, sykepengesøknad-ID, forespørsel-ID og inntektsmelding-ID) ut fra urlen.