### PR TITLE
Sett dokument-ID på transmissions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "2.2.4-magnus-v1-SNAPSHOT"
+version = "2.3.0"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "2.2.4-magnus-v1-"
+version = "2.2.4-magnus-v1-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "2.2.4"
+version = "2.2.4-magnus-v1-"
 
 kotlin {
     compilerOptions {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
@@ -11,6 +11,7 @@ import java.util.UUID
 data class Transmission(
     val type: TransmissionType,
     val extendedType: String,
+    val externalReference: String?,
     val sender: Sender,
     val content: Content,
     val relatedTransmissionId: UUID? = null,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -7,6 +7,7 @@ abstract class TransmissionRequest {
     val vedleggMediaType = ContentType.Application.Json.toString()
     val vedleggConsumerType = Transmission.AttachmentUrlConsumerType.Api
     abstract val extendedType: String
+    abstract val externalReference: String?
     abstract val tittel: String
     abstract val sammendrag: String?
     abstract val vedleggNavn: String
@@ -19,6 +20,7 @@ fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmi
     Transmission(
         type = transmissionRequest.type,
         extendedType = transmissionRequest.extendedType,
+        externalReference = transmissionRequest.externalReference,
         sender = Transmission.Sender("ServiceOwner"),
         relatedTransmissionId = transmissionRequest.relatedTransmissionId,
         content =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -7,11 +7,11 @@ abstract class TransmissionRequest {
     val vedleggMediaType = ContentType.Application.Json.toString()
     val vedleggConsumerType = Transmission.AttachmentUrlConsumerType.Api
     abstract val extendedType: String
-    abstract val externalReference: String?
+    abstract val dokumentId: UUID
     abstract val tittel: String
     abstract val sammendrag: String?
     abstract val vedleggNavn: String
-    abstract val vedleggUrl: String
+    abstract val vedleggBaseUrl: String
     abstract val type: Transmission.TransmissionType
     abstract val relatedTransmissionId: UUID?
 }
@@ -20,7 +20,7 @@ fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmi
     Transmission(
         type = transmissionRequest.type,
         extendedType = transmissionRequest.extendedType,
-        externalReference = transmissionRequest.externalReference,
+        externalReference = transmissionRequest.dokumentId.toString(),
         sender = Transmission.Sender("ServiceOwner"),
         relatedTransmissionId = transmissionRequest.relatedTransmissionId,
         content =
@@ -35,7 +35,7 @@ fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmi
                     urls =
                         listOf(
                             Transmission.Url(
-                                url = transmissionRequest.vedleggUrl,
+                                url = "${transmissionRequest.vedleggBaseUrl}/${transmissionRequest.dokumentId}",
                                 mediaType = transmissionRequest.vedleggMediaType,
                                 consumerType = transmissionRequest.vedleggConsumerType,
                             ),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClientTest.kt
@@ -27,6 +27,7 @@ class DialogportenClientTest :
                 Transmission(
                     type = Transmission.TransmissionType.Information,
                     extendedType = "extendedType",
+                    externalReference = "externalReference",
                     sender = Transmission.Sender(actorType = "actorType"),
                     content = Content.create("title", null),
                     attachments = emptyList(),


### PR DESCRIPTION
**Bakgrunn**
Leverandørene etterlyste en mulighet til å hente dokument-IDen (sykmelding-ID, sykepengesøknad-ID, forespørsel-ID og inntektsmelding-ID) fra et annet sted enn å parse det fra urlen.

**Løsning**
Ta inn dokument-ID som et parameter i `TransmissionRequest`. Bruk dokument-IDen til å lage urlen, slik at det ikke er mulig å lage en transmission med forskjellig id i urlen og i externalref.