### PR TITLE
Vedlegg

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=2.4.2.3
+version=2.4.2
 
 # Plugin versions
 kotlinterVersion=4.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=2.4.2
+version=2.4.2.1
 
 # Plugin versions
 kotlinterVersion=4.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=2.4.2
+version=2.4.2.3
 
 # Plugin versions
 kotlinterVersion=4.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=2.4.1
+version=2.4.2
 
 # Plugin versions
 kotlinterVersion=4.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=2.4.2.1
+version=2.4.2
 
 # Plugin versions
 kotlinterVersion=4.4.0

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/DialogportenClient.kt
@@ -20,7 +20,9 @@ import no.nav.helsearbeidsgiver.dialogporten.domene.PatchOperation
 import no.nav.helsearbeidsgiver.dialogporten.domene.RemoveApiAction
 import no.nav.helsearbeidsgiver.dialogporten.domene.RemoveGuiActions
 import no.nav.helsearbeidsgiver.dialogporten.domene.Transmission
+import no.nav.helsearbeidsgiver.dialogporten.domene.TransmissionRequest
 import no.nav.helsearbeidsgiver.dialogporten.domene.create
+import no.nav.helsearbeidsgiver.dialogporten.domene.toTransmission
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
@@ -52,6 +54,15 @@ class DialogportenClient(
             logAndThrow("Feil ved kall til Dialogporten for å opprette dialog", e)
         }
     }
+
+    suspend fun addTransmission(
+        dialogId: UUID,
+        transmissionRequest: TransmissionRequest,
+    ): UUID =
+        addTransmission(
+            dialogId,
+            transmission = transmissionRequest.toTransmission(),
+        )
 
     suspend fun addTransmission(
         dialogId: UUID,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Attachment.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Attachment.kt
@@ -1,5 +1,6 @@
 package no.nav.helsearbeidsgiver.dialogporten.domene
 
+import io.ktor.http.ContentType
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -37,4 +38,28 @@ fun createAttachment(
                     consumerType = consumerType,
                 ),
             ),
+    )
+
+fun createApiAttachment(
+    displayName: String,
+    url: String,
+    mediaType: String = ContentType.Application.Json.toString(),
+): Attachment =
+    createAttachment(
+        displayName = displayName,
+        url = url,
+        mediaType = mediaType,
+        consumerType = Attachment.Url.AttachmentUrlConsumerType.Api,
+    )
+
+fun createGuiAttachment(
+    displayName: String,
+    url: String,
+    mediaType: String = ContentType.Text.Html.toString(),
+): Attachment =
+    createAttachment(
+        displayName = displayName,
+        url = url,
+        mediaType = mediaType,
+        consumerType = Attachment.Url.AttachmentUrlConsumerType.Gui,
     )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Attachment.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Attachment.kt
@@ -1,0 +1,22 @@
+package no.nav.helsearbeidsgiver.dialogporten.domene
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Attachment(
+    val displayName: List<ContentValueItem>,
+    val urls: List<Url>,
+) {
+    @Serializable
+    data class Url(
+        val url: String,
+        val mediaType: String,
+        val consumerType: AttachmentUrlConsumerType,
+    ) {
+        @Serializable
+        enum class AttachmentUrlConsumerType {
+            Gui,
+            Api,
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Attachment.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Attachment.kt
@@ -20,3 +20,21 @@ data class Attachment(
         }
     }
 }
+
+fun createAttachment(
+    displayName: String,
+    url: String,
+    mediaType: String,
+    consumerType: Attachment.Url.AttachmentUrlConsumerType,
+): Attachment =
+    Attachment(
+        displayName = listOf(ContentValueItem(displayName)),
+        urls =
+            listOf(
+                Attachment.Url(
+                    url = url,
+                    mediaType = mediaType,
+                    consumerType = consumerType,
+                ),
+            ),
+    )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
@@ -50,4 +50,4 @@ data class Transmission(
     }
 }
 
-fun Transmission.addAttachment(attachment: Attachment): Transmission = copy(attachments = (attachments.orEmpty() + attachment))
+fun Transmission.addAttachment(vararg attachments: Attachment): Transmission = copy(attachments = this.attachments.orEmpty() + attachments)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
@@ -49,5 +49,3 @@ data class Transmission(
         Correction,
     }
 }
-
-fun Transmission.addAttachment(vararg attachments: Attachment): Transmission = copy(attachments = this.attachments.orEmpty() + attachments)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
@@ -2,6 +2,7 @@
 
 package no.nav.helsearbeidsgiver.dialogporten.domene
 
+import io.ktor.http.Url
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -48,23 +49,6 @@ data class Transmission(
         // Update to previously submitted data
         Correction,
     }
-
-    @Serializable
-    data class Attachment(
-        val displayName: List<ContentValueItem>,
-        val urls: List<Url>,
-    )
-
-    @Serializable
-    data class Url(
-        val url: String,
-        val mediaType: String,
-        val consumerType: AttachmentUrlConsumerType,
-    )
-
-    @Serializable
-    enum class AttachmentUrlConsumerType {
-        Gui,
-        Api,
-    }
 }
+
+fun Transmission.addAttachment(attachment: Attachment): Transmission = copy(attachments = (attachments.orEmpty() + attachment))

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/Transmission.kt
@@ -2,7 +2,6 @@
 
 package no.nav.helsearbeidsgiver.dialogporten.domene
 
-import io.ktor.http.Url
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -10,7 +10,8 @@ abstract class TransmissionRequest {
     abstract val tittel: String
     abstract val sammendrag: String?
     abstract val vedleggNavn: String
-    abstract val vedleggBaseUrl: String
+    abstract val vedleggApiBaseUrl: String
+    abstract val vadleggGuiBaseUrl: String
     abstract val type: Transmission.TransmissionType
     abstract val relatedTransmissionId: UUID?
 }
@@ -29,27 +30,60 @@ fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmi
             ),
         attachments =
             listOf(
-                Transmission.Attachment(
+                Attachment(
                     displayName = listOf(ContentValueItem(transmissionRequest.vedleggNavn)),
                     urls =
                         listOf(
-                            Transmission.Url(
-                                url = "${transmissionRequest.vedleggBaseUrl}/${transmissionRequest.dokumentId}",
+                            Attachment.Url(
+                                url = "${transmissionRequest.vedleggApiBaseUrl}/${transmissionRequest.dokumentId}",
                                 mediaType = transmissionRequest.vedleggMediaType,
-                                consumerType = Transmission.AttachmentUrlConsumerType.Api,
+                                consumerType = Attachment.Url.AttachmentUrlConsumerType.Api,
                             ),
                         ),
                 ),
-                Transmission.Attachment(
+                Attachment(
                     displayName = listOf(ContentValueItem(transmissionRequest.vedleggNavn)),
                     urls =
                         listOf(
-                            Transmission.Url(
-                                url = transmissionRequest.vedleggBaseUrl,
+                            Attachment.Url(
+                                url = transmissionRequest.vadleggGuiBaseUrl,
                                 mediaType = transmissionRequest.vedleggMediaType,
-                                consumerType = Transmission.AttachmentUrlConsumerType.Gui,
+                                consumerType = Attachment.Url.AttachmentUrlConsumerType.Gui,
                             ),
                         ),
                 ),
             ),
     )
+
+fun createTransmission(transmissionRequest: TransmissionRequest): Transmission =
+    Transmission(
+        type = transmissionRequest.type,
+        extendedType = transmissionRequest.extendedType,
+        externalReference = transmissionRequest.dokumentId.toString(),
+        sender = Transmission.Sender("ServiceOwner"),
+        relatedTransmissionId = transmissionRequest.relatedTransmissionId,
+        content =
+            Content.create(
+                title = transmissionRequest.tittel,
+                summary = transmissionRequest.sammendrag,
+            ),
+    )
+
+fun createAttachment(
+    displayName: String,
+    url: String,
+    mediaType: String,
+    consumerType: Attachment.Url.AttachmentUrlConsumerType,
+): Attachment =
+    Attachment(
+        displayName = listOf(ContentValueItem(displayName)),
+        urls =
+            listOf(
+                Attachment.Url(
+                    url = url,
+                    mediaType = mediaType,
+                    consumerType = consumerType,
+                ),
+            ),
+    )
+

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -86,4 +86,3 @@ fun createAttachment(
                 ),
             ),
     )
-

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -9,6 +9,7 @@ abstract class TransmissionRequest {
     abstract val sammendrag: String?
     abstract val type: Transmission.TransmissionType
     abstract val relatedTransmissionId: UUID?
+    abstract val attachments: List<Attachment>?
 }
 
 fun TransmissionRequest.toTransmission(): Transmission =
@@ -23,4 +24,5 @@ fun TransmissionRequest.toTransmission(): Transmission =
                 title = tittel,
                 summary = sammendrag,
             ),
+        attachments = attachments,
     )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -1,10 +1,8 @@
 package no.nav.helsearbeidsgiver.dialogporten.domene
 
-import io.ktor.http.ContentType
 import java.util.UUID
 
 abstract class TransmissionRequest {
-    val vedleggMediaType = ContentType.Application.Json.toString()
     abstract val extendedType: String
     abstract val dokumentId: UUID
     abstract val tittel: String

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/dialogporten/domene/TransmissionRequest.kt
@@ -9,80 +9,20 @@ abstract class TransmissionRequest {
     abstract val dokumentId: UUID
     abstract val tittel: String
     abstract val sammendrag: String?
-    abstract val vedleggNavn: String
-    abstract val vedleggApiBaseUrl: String
-    abstract val vadleggGuiBaseUrl: String
     abstract val type: Transmission.TransmissionType
     abstract val relatedTransmissionId: UUID?
 }
 
-fun lagTransmissionMedVedlegg(transmissionRequest: TransmissionRequest): Transmission =
+fun TransmissionRequest.toTransmission(): Transmission =
     Transmission(
-        type = transmissionRequest.type,
-        extendedType = transmissionRequest.extendedType,
-        externalReference = transmissionRequest.dokumentId.toString(),
+        type = type,
+        extendedType = extendedType,
+        externalReference = dokumentId.toString(),
         sender = Transmission.Sender("ServiceOwner"),
-        relatedTransmissionId = transmissionRequest.relatedTransmissionId,
+        relatedTransmissionId = relatedTransmissionId,
         content =
             Content.create(
-                title = transmissionRequest.tittel,
-                summary = transmissionRequest.sammendrag,
-            ),
-        attachments =
-            listOf(
-                Attachment(
-                    displayName = listOf(ContentValueItem(transmissionRequest.vedleggNavn)),
-                    urls =
-                        listOf(
-                            Attachment.Url(
-                                url = "${transmissionRequest.vedleggApiBaseUrl}/${transmissionRequest.dokumentId}",
-                                mediaType = transmissionRequest.vedleggMediaType,
-                                consumerType = Attachment.Url.AttachmentUrlConsumerType.Api,
-                            ),
-                        ),
-                ),
-                Attachment(
-                    displayName = listOf(ContentValueItem(transmissionRequest.vedleggNavn)),
-                    urls =
-                        listOf(
-                            Attachment.Url(
-                                url = transmissionRequest.vadleggGuiBaseUrl,
-                                mediaType = transmissionRequest.vedleggMediaType,
-                                consumerType = Attachment.Url.AttachmentUrlConsumerType.Gui,
-                            ),
-                        ),
-                ),
-            ),
-    )
-
-fun createTransmission(transmissionRequest: TransmissionRequest): Transmission =
-    Transmission(
-        type = transmissionRequest.type,
-        extendedType = transmissionRequest.extendedType,
-        externalReference = transmissionRequest.dokumentId.toString(),
-        sender = Transmission.Sender("ServiceOwner"),
-        relatedTransmissionId = transmissionRequest.relatedTransmissionId,
-        content =
-            Content.create(
-                title = transmissionRequest.tittel,
-                summary = transmissionRequest.sammendrag,
-            ),
-    )
-
-fun createAttachment(
-    displayName: String,
-    url: String,
-    mediaType: String,
-    consumerType: Attachment.Url.AttachmentUrlConsumerType,
-): Attachment =
-    Attachment(
-        displayName = listOf(ContentValueItem(displayName)),
-        urls =
-            listOf(
-                Attachment.Url(
-                    url = url,
-                    mediaType = mediaType,
-                    consumerType = consumerType,
-                ),
+                title = tittel,
+                summary = sammendrag,
             ),
     )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/MockData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/dialogporten/MockData.kt
@@ -17,29 +17,4 @@ object MockData {
         )
 
     val gyldingRespons = "0194cb3a-6f4e-7707-a506-a1db2b5c37fa"
-
-    val transmissionsJson =
-        """
-        [
-               {
-                   "id": "0194cb3a-6f4e-7707-a506-a1db2b5c37fa",
-                   "type": "Information",
-                   "extendedType": "extendedType",
-                   "sender": {
-                       "actorType": "actorType"
-                   },
-                   "content": {
-                       "title": {
-                           "value": [
-                               {
-                                   "value": "title",
-                                   "languageCode": "nb"
-                               }
-                           ],
-                           "mediaType": "text/plain"
-                       }
-                   }
-               }
-           ]
-        """.trimIndent()
 }


### PR DESCRIPTION
I denne PR-en har jeg ryddet opp i hvordan Attachment-objekter opprettes.

- Bruker nå factory-metoder for å lage vedlegg på en mer oversiktlig måte.
- Lagt til støtte for å opprette GUI- og API-vedlegg hver for seg.
